### PR TITLE
Fix Attachements initialization on PostmarkMessage

### DIFF
--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -103,6 +103,7 @@ namespace PostmarkDotNet
             TextBody = isHtml ? null : body;
             HtmlBody = isHtml ? body : null;
             Headers = headers ?? new NameValueCollection(0);
+            Attachments = new List<PostmarkMessageAttachment>(0);
         }
 
 


### PR DESCRIPTION
Fixed issue where Attachments is null on Postmark depending on which constructor you use, resulting in errors if you then call AddAttachment.
